### PR TITLE
Storage override - accessing generated values

### DIFF
--- a/src/pages/cli/storage/override.mdx
+++ b/src/pages/cli/storage/override.mdx
@@ -67,9 +67,9 @@ import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper
 import * as s3 from '@aws-cdk/aws-s3';
 
 export function override(resources: AmplifyS3ResourceTemplate) {
-    const currentsettings  = resources.s3Bucket.notificationConfiguration as s3.CfnBucket.NotificationConfigurationProperty;
-    const previousLambdaConfig  = currentsettings.lambdaConfigurations as s3.CfnBucket.LambdaConfigurationProperty[];
-    const farn = currentsettings.lambdaConfigurations[0].function;
+    const currentSettings  = resources.s3Bucket.notificationConfiguration as s3.CfnBucket.NotificationConfigurationProperty;
+    const previousLambdaConfig  = currentSettings.lambdaConfigurations as s3.CfnBucket.LambdaConfigurationProperty[];
+    const functionArn = currentSettings.lambdaConfigurations[0].function;
     const newConfig = {
         event: "s3:ObjectCreated:*",
         filter:{
@@ -82,7 +82,7 @@ export function override(resources: AmplifyS3ResourceTemplate) {
                 ]
             }
         },
-        function: farn
+        function: functionArn
     } as s3.CfnBucket.LambdaConfigurationProperty;
     // here we append custom config with amplify generated config
     previousLambdaConfig.push(newConfig);

--- a/src/pages/cli/storage/override.mdx
+++ b/src/pages/cli/storage/override.mdx
@@ -57,3 +57,39 @@ You can override the following DynamoDB resources that Amplify generates:
 |Amplify-generated resource|Description|
 |-|-|
 |[dynamoDBTable](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/aws-resource-dynamodb-table.html)|The DynamoDB table that Amplify creates upon `amplify add storage`|
+
+## Accessing Amplify-generated values
+
+Override function can be used to get access to Amplify-generated values. E.g. to add a new notification rule for Lambda Trigger function defined using CLI, we need to access the ARN of the function:
+
+```
+import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
+import * as s3 from '@aws-cdk/aws-s3';
+
+export function override(resources: AmplifyS3ResourceTemplate) {
+    const currentsettings  = resources.s3Bucket.notificationConfiguration as s3.CfnBucket.NotificationConfigurationProperty;
+    const previousLambdaConfig  = currentsettings.lambdaConfigurations as s3.CfnBucket.LambdaConfigurationProperty[];
+    const farn = currentsettings.lambdaConfigurations[0].function;
+    const newConfig = {
+        event: "s3:ObjectCreated:*",
+        filter:{
+            s3Key:{
+                rules:[
+                    {
+                        name: "prefix",
+                        value: "additionalPrefix/"
+                    }
+                ]
+            }
+        },
+        function: farn
+    } as s3.CfnBucket.LambdaConfigurationProperty;
+    // here we append custom config with amplify generated config
+    previousLambdaConfig.push(newConfig);
+    const notificationConfigurationProperty: s3.CfnBucket.NotificationConfigurationProperty = {
+        lambdaConfigurations: previousLambdaConfig
+    };
+
+    resources.s3Bucket.notificationConfiguration = notificationConfigurationProperty;
+}
+```

--- a/src/pages/cli/storage/override.mdx
+++ b/src/pages/cli/storage/override.mdx
@@ -62,7 +62,7 @@ You can override the following DynamoDB resources that Amplify generates:
 
 Override function can be used to get access to Amplify-generated values. E.g. to add a new notification rule for Lambda Trigger function defined using CLI, we need to access the ARN of the function:
 
-```
+```ts
 import { AmplifyS3ResourceTemplate } from '@aws-amplify/cli-extensibility-helper';
 import * as s3 from '@aws-cdk/aws-s3';
 


### PR DESCRIPTION
Storage override - accessing Amplify-generated values. This code was provided by @akshbhu in an issue I opened and I find it very useful for developers inexperienced with TypeScript

_Issue #, if available:_

_Description of changes:_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
